### PR TITLE
chore: add mergify auto-merge for renovate PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -6,3 +6,20 @@ pull_request_rules:
       label:
         toggle:
           - conflict
+
+  - name: Automatic merge on approval
+    conditions:
+      - '#commits-behind=0'
+      - or:
+          - '#approved-reviews-by>=1'
+          - label=ci:auto-merge
+      - not:
+          and:
+            - 'head*=renovate/lockfile-maintenance-*'
+            - 'created-at>24h ago'
+      - base=master
+      - check-success=build
+      - check-success=vulnerability-scan
+    actions:
+      merge:
+        method: squash

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,5 +5,10 @@
     "local>trim21/renovate-config:monthly",
     "local>trim21/renovate-config:app",
     "local>trim21/renovate-config:go"
-  ]
+  ],
+  "labels": [
+    "ci:auto-merge",
+    "dependencies"
+  ],
+  "prConcurrentLimit": 3
 }

--- a/.github/workflows/security-pr.yaml
+++ b/.github/workflows/security-pr.yaml
@@ -4,11 +4,6 @@ on:
   pull_request:
     branches:
       - master
-    paths:
-      - "**.go"
-      - "go.mod"
-      - "go.sum"
-      - ".github/workflows/security.yaml"
   schedule:
     - cron: "45 8 * * 5"
 


### PR DESCRIPTION
Summary:
- add Mergify automatic merge rule (approval or ci:auto-merge label)
- require check-success build on master
- add Renovate labels ci:auto-merge and dependencies
- set Renovate prConcurrentLimit to 3